### PR TITLE
Fix: create post

### DIFF
--- a/app/src/components/post/edit/PostEditor.tsx
+++ b/app/src/components/post/edit/PostEditor.tsx
@@ -12,18 +12,15 @@ interface PostEditorProps {
 
 export const PostEditor: React.FC<PostEditorProps> = ({ id }) => {
     const { post = undefined } = usePost({ id });
-    const isModifying = !!post;
+    const isModifying = !!post?.id;
     const { createPost, updatePost } = usePostMutation({
-        onMutate: async (post?: Post) => {
-            if (!post) {
-                return;
-            }
+        onSuccess: async ({ result: { id } }: { result: { id: string } }) => {
             if (isModifying) {
                 alert("수정되었습니다.");
             } else {
                 alert("작성되었습니다.");
             }
-            router.push(`/post/${post!.id}`);
+            router.push(`/post/${id}`);
         },
     });
 

--- a/app/src/hooks/post/usePostMutation.ts
+++ b/app/src/hooks/post/usePostMutation.ts
@@ -5,9 +5,13 @@ import { Post } from "@/lib/internal/post/post.model";
 import { useMutation } from "@tanstack/react-query";
 
 export const usePostMutation = ({
-    onMutate,
+    onSuccess,
 }: {
-    onMutate?: (post?: Post) => Promise<void>;
+    onSuccess?: ({
+        result: { id },
+    }: {
+        result: { id: string };
+    }) => Promise<void>;
 } = {}) => {
     const invalidateQueries = async () => {
         for (const key of [
@@ -25,7 +29,7 @@ export const usePostMutation = ({
             await api.delete(`/api/post/${id}`);
             return undefined;
         },
-        onMutate: invalidateQueries,
+        onSuccess: invalidateQueries,
     });
 
     const { mutateAsync: createPost } = useMutation({
@@ -38,9 +42,9 @@ export const usePostMutation = ({
 
             return data;
         },
-        onMutate: async (post: Post) => {
+        onSuccess: async (res: any) => {
             await invalidateQueries();
-            await onMutate?.(post);
+            await onSuccess?.(res);
         },
     });
 
@@ -54,9 +58,9 @@ export const usePostMutation = ({
 
             return data;
         },
-        onMutate: async (post: Post) => {
+        onSuccess: async (res: any) => {
             await invalidateQueries();
-            await onMutate?.(post);
+            await onSuccess?.(res);
         },
     });
 


### PR DESCRIPTION
신규 포스트 작성시, update 메소드가 발생하는 버그
post대신, post.id 존재여부로 수정여부를 판단하도록 변경

post mutate시, onSuccess메소드가 아니라 onMutate메소드가 사용되어
작성 완료된 post의 id를 불러오지 못하는 버그 
메소드 변경으로 수정